### PR TITLE
Bump puppetboard to v2.1.0 to fix metrics 404 issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ RANDOM_PORT := $(shell expr $$(( 8000 + (`id -u` % 1000) + 3 )))
 
 # Increment this when new releases are made at
 # https://github.com/voxpupuli/puppetboard/releases
-PB_VERSION := v2.0.0
+PB_VERSION := v2.1.0
 
 .PHONY: dev
 dev: cook-image


### PR DESCRIPTION
This should fix the current 404 error on the puppetboard homepage. The puppetboard changelog is at https://github.com/voxpupuli/puppetboard/blob/master/CHANGELOG.md and has more details.